### PR TITLE
Configure Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,56 @@
+
+# Created by https://www.gitignore.io/api/ruby
+
+### Ruby ###
+*.gem
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Used by dotenv library to load environment variables.
+# .env
+
+## Specific to RubyMotion:
+.dat*
+.repl_history
+build/
+*.bridgesupport
+build-iPhoneOS/
+build-iPhoneSimulator/
+
+## Specific to RubyMotion (use of CocoaPods):
+#
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+#
+# vendor/Pods/
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# for a library or gem, you might want to ignore these files since the code is
+# intended to run in multiple environments; otherwise, check them in:
+Gemfile.lock
+.ruby-version
+.ruby-gemset
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+# End of https://www.gitignore.io/api/ruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM starefossen/github-pages:latest
+
+COPY Gemfile /usr/src/app
+RUN bundle install

--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,7 @@
-exclude: [vendor]
+exclude:
+    - Dockerfile
+    - Gemfile
+    - Gemfile.lock
+    - README.md
+    - docker-compose.yml
+    - vendor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+    jekyll:
+        build: .
+        ports:
+            - 4000:4000
+        volumes:
+            - .:/usr/src/app


### PR DESCRIPTION
Add Dockerfile and docker-compose.yml to configure a 'jekyll' service based on the starefossen/github-pages Docker image with project dependencies installed, with port 4000 on the host linked to port 4000 on the container, and with the current working directory on the host mapped to the /usr/src/app volume on the container.

Update _config.yml to exclude non-build files from the Jekyll site.

Add .gitignore to exclude Ruby build artifacts from the repository.